### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/bap/barcode/modes/barcodeHelp.py
+++ b/bap/barcode/modes/barcodeHelp.py
@@ -5,8 +5,8 @@ import sys
 import gzip
 from itertools import repeat
 
-from fuzzywuzzy import fuzz
-from fuzzywuzzy import process
+from rapidfuzz import fuzz
+from rapidfuzz import process
 from fuzzysearch import find_near_matches
 
 def batch_iterator(iterator, batch_size):

--- a/bap/barcode/modes/biorad_v1.py
+++ b/bap/barcode/modes/biorad_v1.py
@@ -20,8 +20,8 @@ from itertools import repeat
 from Bio import SeqIO
 from Bio.SeqIO.QualityIO import FastqGeneralIterator
 
-from fuzzywuzzy import fuzz
-from fuzzywuzzy import process
+from rapidfuzz import fuzz
+from rapidfuzz import process
 from fuzzysearch import find_near_matches
 
 #### OPTIONS ####

--- a/bap/barcode/modes/biorad_v2-multi.py
+++ b/bap/barcode/modes/biorad_v2-multi.py
@@ -20,8 +20,8 @@ from itertools import repeat
 from Bio import SeqIO
 from Bio.SeqIO.QualityIO import FastqGeneralIterator
 
-from fuzzywuzzy import fuzz
-from fuzzywuzzy import process
+from rapidfuzz import fuzz
+from rapidfuzz import process
 from fuzzysearch import find_near_matches
 
 #### OPTIONS ####

--- a/bap/barcode/modes/biorad_v2.py
+++ b/bap/barcode/modes/biorad_v2.py
@@ -20,8 +20,8 @@ from itertools import repeat
 from Bio import SeqIO
 from Bio.SeqIO.QualityIO import FastqGeneralIterator
 
-from fuzzywuzzy import fuzz
-from fuzzywuzzy import process
+from rapidfuzz import fuzz
+from rapidfuzz import process
 from fuzzysearch import find_near_matches
 
 #### OPTIONS ####

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ bap: Bead-based scATAC-seq data Processing
 from setuptools import find_packages, setup
 from distutils.core import setup, Extension
 
-dependencies = ['python-Levenshtein','biopython','fuzzysearch','fuzzywuzzy','click', 'pytest', 'snakemake', 'optparse-pretty', 'regex', 'pysam', 'ruamel.yaml']
+dependencies = ['biopython','fuzzysearch','click', 'pytest', 'snakemake', 'optparse-pretty', 'regex', 'pysam', 'ruamel.yaml']
 
 setup(
     name='bap-atac',


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.